### PR TITLE
Stop if there's no mapID

### DIFF
--- a/MapLine.lua
+++ b/MapLine.lua
@@ -80,6 +80,9 @@ LineFrame:SetScript('OnUpdate', function(self, elapsed)
 		
 		-- if not onMap and continentID == 9 then return end -- don't draw line to other argus maps
 		local bestMap = C_Map.GetBestMapForUnit("player");
+		if not bestMap then
+			return
+		end
 		local playerMapPos = C_Map.GetPlayerMapPosition(bestMap,"player")
 			
 			


### PR DESCRIPTION
This happens in the portal room added in 10.2.