### PR TITLE
Nil check for `a`

### DIFF
--- a/MapLine.lua
+++ b/MapLine.lua
@@ -19,15 +19,17 @@ local function GetMapSize() -- Return dimensions and offset of current map
 end
 
 local function GetIntersect(px, py, a, sx, sy, ex, ey)
-	a = (a + PI / 2) % (PI * 2)
-	local dx, dy = -math.cos(a), math.sin(a)
-	local d = dx * (sy - ey) + dy * (ex - sx)
-	if d ~= 0 and dx ~= 0 then
-		local s = (dx * (sy - py) - dy * (sx - px)) / d
-		if s >= 0 and s <= 1 then
-			local r = (sx + (ex - sx) * s - px) / dx
-			if r >= 0 then
-				return sx + (ex - sx) * s, sy + (ey - sy) * s, r, s
+	if a then 
+		a = (a + PI / 2) % (PI * 2)
+		local dx, dy = -math.cos(a), math.sin(a)
+		local d = dx * (sy - ey) + dy * (ex - sx)
+		if d ~= 0 and dx ~= 0 then
+			local s = (dx * (sy - py) - dy * (sx - px)) / d
+			if s >= 0 and s <= 1 then
+				local r = (sx + (ex - sx) * s - px) / dx
+				if r >= 0 then
+					return sx + (ex - sx) * s, sy + (ey - sy) * s, r, s
+				end
 			end
 		end
 	end


### PR DESCRIPTION
This fixes this error:

```denizenscript
2x MapLine/MapLine.lua:22: attempt to perform arithmetic on local 'a' (a nil value)
[string "@MapLine/MapLine.lua"]:22: in function <MapLine/MapLine.lua:21>
[string "@MapLine/MapLine.lua"]:114: in function <MapLine/MapLine.lua:65>

Locals:
px = 7112
py = -1708.000244
a = nil
sx = 10891.700195
sy = 1393.750000
ex = 3414.580078
ey = 1393.750000
(*temporary) = 1.570796
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = "attempt to perform arithmetic on local 'a' (a nil value)"

```
