### PR TITLE
Changed the check for player speed to include the new method for checking Skyriding (Dragonriding) speed

### DIFF
--- a/MapLine.lua
+++ b/MapLine.lua
@@ -66,9 +66,15 @@ Line:SetEndPoint('CENTER', EndPoint, 0, 0)
 local WorldMapUpdated, PlayerFacing = false, 0
 LineFrame:SetScript('OnUpdate', function(self, elapsed)
 	local angle = GetPlayerFacing()
+
+	-- Skyriding (Dragnriding) uses a different method of determiniing movement speed
+	-- Check if you're skyriding and if not, use the normal method
+	local isGliding, canGlide, forwardSpeed = C_PlayerInfo.GetGlidingInfo()
+	local speed = isGliding and forwardSpeed or GetUnitSpeed("player")
+
 	if not angle and Line:IsShown() then
 		Line:Hide()
-	elseif WorldMapUpdated or GetUnitSpeed('player') > 0 or angle ~= PlayerFacing then
+	elseif WorldMapUpdated or speed > 0 or angle ~= PlayerFacing then
 		WorldMapUpdated = false
 		PlayerFacing = angle
 		Line:Hide()


### PR DESCRIPTION
If you're skyriding (dragonriding) but not changing your angle, the map line doesn't update and starts to lag behind the player on the map. The issue was that `GetUnitSpeed('player')` returns `0` when you're dragonriding, no matter how fast you're going. It's a weird choice for the API, but there is [a workaround documented using C_PlayerInfo.GetGlidingInfo](https://wowpedia.fandom.com/wiki/API_C_PlayerInfo.GetGlidingInfo). I integrated itinto the speed check and I can now skyride in the pre-patch with the map line always up-to-date.